### PR TITLE
Add env variable "notification_level" with all / failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This expects kube config to be in `~/.kube/config` (default)
 $ export webhook="slack_webhook_url" && export namespace="<namespace_name>" && go build &&  ./k8s-job-notify
 ```
 
+You can also adjust the notification level to `failed` instead of `all` so that it only sends failed notificatinos.
+
+```sh
+$ export webhook="slack_webhook_url" && export namespace="<namespace_name>" && export notification_level="failed" && go build &&  ./k8s-job-notify
+```
+
 Docker 🐳
 
 ---
@@ -76,6 +82,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: incluster
               value: '1'
+            - name: "notification_level"
+              value: 'all'  # or 'failed'
           image: sukeesh/k8s-job-notify:<tag>
           name: k8s-job-notify
           resources:

--- a/env/config.go
+++ b/env/config.go
@@ -19,6 +19,14 @@ func GetSlackWebHookURL() (webhook string, err error) {
 	return webhook, nil
 }
 
+func GetNotificationLevel() (level string) {
+	if level = os.Getenv("notification_level"); level == "" {
+		level = "all"
+	}
+	return level
+}
+
+
 func IsInCluster() bool {
 	inCluster := os.Getenv("incluster")
 	return inCluster == "1"

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	namespace := env.GetNamespace()
 	log.Printf("fetching jobs from %s namespace", namespace)
-	level := env.GetNotificationLeve()
+	level := env.GetNotificationLevel()
 	log.Printf("notification_level set at '%s'", level)
 	for {
 		jobs, err := client.ListJobs(namespace)

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ func main() {
 
 	namespace := env.GetNamespace()
 	log.Printf("fetching jobs from %s namespace", namespace)
+	level := env.GetNotificationLeve()
+	log.Printf("notification_level set at '%s'", level)
 	for {
 		jobs, err := client.ListJobs(namespace)
 		if err != nil {
@@ -51,20 +53,28 @@ func main() {
 			// uniqueness of the job. so that duplicated messages to slack can be avoided
 			jobUniqueHash := job.Name + job.CreationTimestamp.String()
 			if pastJobs[jobUniqueHash] == false {
-				if job.Status.Succeeded > 0 && (job.Status.CompletionTime.Add(20*time.Minute).Unix() > time.Now().Unix()) {
-					timeSinceCompletion := time.Now().Sub(job.Status.CompletionTime.Time).Minutes()
-					err = slack.SendSlackMessage(message.JobSuccess(clusterName, job.Name, timeSinceCompletion))
-					if err != nil {
-						log.Fatalf("sending a message to slack failed %v", zap.Error(err))
-					}
-					pastJobs[jobUniqueHash] = true
-				} else if job.Status.Failed > 0 {
-					if job.Status.StartTime.Add(5*time.Hour).Unix() > time.Now().Unix() {
-						err = slack.SendSlackMessage(message.JobFailure(clusterName, job.Name))
+				if level == 'all' {
+					// Send success notifications.
+					if job.Status.Succeeded > 0 &&  (job.Status.CompletionTime.Add(20*time.Minute).Unix() > time.Now().Unix()) {
+						timeSinceCompletion := time.Now().Sub(job.Status.CompletionTime.Time).Minutes()
+						err = slack.SendSlackMessage(message.JobSuccess(clusterName, job.Name, timeSinceCompletion))
 						if err != nil {
 							log.Fatalf("sending a message to slack failed %v", zap.Error(err))
 						}
 						pastJobs[jobUniqueHash] = true
+					}
+				}
+
+				if level == 'failed' || level == 'all' {
+					// Send failed notifications.
+				  if job.Status.Failed > 0 {
+						if job.Status.StartTime.Add(5*time.Hour).Unix() > time.Now().Unix() {
+							err = slack.SendSlackMessage(message.JobFailure(clusterName, job.Name))
+							if err != nil {
+								log.Fatalf("sending a message to slack failed %v", zap.Error(err))
+							}
+							pastJobs[jobUniqueHash] = true
+						}
 					}
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 			// uniqueness of the job. so that duplicated messages to slack can be avoided
 			jobUniqueHash := job.Name + job.CreationTimestamp.String()
 			if pastJobs[jobUniqueHash] == false {
-				if level == 'all' {
+				if level == "all" {
 					// Send success notifications.
 					if job.Status.Succeeded > 0 &&  (job.Status.CompletionTime.Add(20*time.Minute).Unix() > time.Now().Unix()) {
 						timeSinceCompletion := time.Now().Sub(job.Status.CompletionTime.Time).Minutes()
@@ -65,7 +65,7 @@ func main() {
 					}
 				}
 
-				if level == 'failed' || level == 'all' {
+				if level == "failed" || level == "all" {
 					// Send failed notifications.
 				  if job.Status.Failed > 0 {
 						if job.Status.StartTime.Add(5*time.Hour).Unix() > time.Now().Unix() {


### PR DESCRIPTION
The notification_level defaults to "all", but can be set to "failed" from env variable.

If set to "failed" it will only send notification when a job fails, so when you have many successful jobs all the time, it creates less noise in the slack channel.